### PR TITLE
Updated ammo check

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -170,6 +170,8 @@ AddEventHandler("syn_weapons:getandcheckammo", function(player, key, qt, item, m
             if contains then
                 if count >= max then
                     return --TriggerClientEvent("syn_weapons:givebackbox", _source, item)
+                elseif max <= (qt+count) then
+                    return
                 elseif (qt + count) >= max then
                     qt = max - count
                 end


### PR DESCRIPTION
 Updated ammo check to not allow for ammo to be used if the quantity plus the current ammo is greater than the max ammo.